### PR TITLE
fix: Chrome treo sau khi dừng ghi hình trên trang dev có Hot Reload

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -330,10 +330,15 @@ const SW = {
 
   startKeepalive() {
     chrome.alarms.create(this.KEEPALIVE_NAME, { periodInMinutes: 0.4 });
+    this._flushInterval = setInterval(() => this.flushBuffer(), this.FLUSH_INTERVAL);
   },
 
   stopKeepalive() {
     chrome.alarms.clear(this.KEEPALIVE_NAME);
+    if (this._flushInterval) {
+      clearInterval(this._flushInterval);
+      this._flushInterval = null;
+    }
   }
 };
 
@@ -355,7 +360,6 @@ chrome.commands.onCommand.addListener(async (command) => {
 });
 
 SW.init();
-setInterval(() => SW.flushBuffer(), SW.FLUSH_INTERVAL);
 
 // --- Dev auto-reload (disabled in production builds) ---
 // To enable during development, set localStorage['debug-helper-dev'] = '1'

--- a/content/bridge.js
+++ b/content/bridge.js
@@ -1,8 +1,6 @@
 // ISOLATED world — relays postMessage from MAIN world to service worker
 (() => {
-  if (window.__debugHelperBridge) {
-    try { if (chrome.runtime?.id) return; } catch {}
-  }
+  if (window.__debugHelperBridge) return;
   window.__debugHelperBridge = true;
   window.addEventListener('message', (e) => {
     if (e.source !== window) return;

--- a/content/console-capture.js
+++ b/content/console-capture.js
@@ -4,6 +4,15 @@
   if (window[PREFIX + 'consolePatched']) return;
   window[PREFIX + 'consolePatched'] = true;
 
+  let recording = false;
+
+  window.addEventListener('message', (e) => {
+    if (e.source !== window) return;
+    if (!e.data || e.data.source !== 'debug-helper-isolated') return;
+    if (e.data.type === 'recording:start') recording = true;
+    if (e.data.type === 'recording:stop') recording = false;
+  });
+
   const origConsole = {
     log: console.log.bind(console),
     warn: console.warn.bind(console),
@@ -22,6 +31,7 @@
   }
 
   function post(level, args, stack) {
+    if (!recording) return;
     window.postMessage({
       source: 'debug-helper-main',
       type: 'event:console',

--- a/content/network-capture.js
+++ b/content/network-capture.js
@@ -4,9 +4,19 @@
   if (window[PREFIX + 'networkPatched']) return;
   window[PREFIX + 'networkPatched'] = true;
 
+  let recording = false;
+
+  window.addEventListener('message', (e) => {
+    if (e.source !== window) return;
+    if (!e.data || e.data.source !== 'debug-helper-isolated') return;
+    if (e.data.type === 'recording:start') recording = true;
+    if (e.data.type === 'recording:stop') recording = false;
+  });
+
   const MAX_BODY = 10240;
 
   function post(data) {
+    if (!recording) return;
     window.postMessage({
       source: 'debug-helper-main',
       type: 'event:network',

--- a/content/recorder.js
+++ b/content/recorder.js
@@ -169,6 +169,7 @@
   }
 
   function startRecording() {
+    window.postMessage({ source: 'debug-helper-isolated', type: 'recording:start' }, '*');
     recording = true;
     document.addEventListener('click', onClick, true);
     document.addEventListener('dblclick', onClick, true);
@@ -179,6 +180,7 @@
   }
 
   function stopRecording() {
+    window.postMessage({ source: 'debug-helper-isolated', type: 'recording:stop' }, '*');
     recording = false;
     document.removeEventListener('click', onClick, true);
     document.removeEventListener('dblclick', onClick, true);


### PR DESCRIPTION
Fixes #3

## Vấn đề

Sau khi stop recording trên trang Vite/HMR dev server, Chrome CPU tăng ~200% trong vòng 30–120 giây, trình duyệt không thể dùng được. Đã xảy ra 2 lần Chrome hard crash khi điều tra.

Số liệu đo được từ crash log:
- **~14.500 SW messages/giây** tại peak
- Ring buffer 3.000 entry bị lấp đầy trong 207ms
- Bridge đăng ký lặp **11–14 lần** mỗi session

## Nguyên nhân gốc

### Suspect A — `setInterval` không bao giờ bị clear

```js
// service-worker.js — tồn tại suốt đời SW, không dừng khi stop session
setInterval(() => SW.flushBuffer(), SW.FLUSH_INTERVAL);
```

### Suspect B — Console/network interceptors không tắt sau stop *(nguyên nhân chính)*

`console-capture.js` và `network-capture.js` patch `console.*`/`fetch`/`XHR` khi inject nhưng không có cơ chế dừng. Sau `session:stop` vẫn tiếp tục gọi `window.postMessage()` cho mỗi console log và network request — trên HMR dev server, đây là luồng sự kiện liên tục.

### Suspect C — `bridge.js` đăng ký listener nhiều lần *(bộ nhân)*

```js
// Guard lỗi: chrome.runtime throw khi SW terminated, catch nuốt lỗi
if (window.__debugHelperBridge) {
  try { if (chrome.runtime?.id) return; } catch {}
}
```

Mỗi HMR reload khi SW đang bị terminate → guard fail → listener đăng ký thêm 1 lần. Sau 11–14 HMR reload → 11–14 listener song song → mỗi console event tạo ra 11–14 SW message.

**Kết hợp:** HMR reload → B tạo event storm → C nhân 14x → A amplify thêm → SW xử lý hàng chục nghìn async storage read/giây → Chrome crash.

## Fix

### `content/bridge.js` — đơn giản hóa guard
```js
// Trước
if (window.__debugHelperBridge) {
  try { if (chrome.runtime?.id) return; } catch {}
}
// Sau
if (window.__debugHelperBridge) return;
```
Flag nằm trong MAIN world, không bị ảnh hưởng bởi SW lifecycle.

### `content/console-capture.js` + `content/network-capture.js` — recording flag
- Thêm `let recording = false` (mặc định tắt — an toàn)
- `post()` return ngay khi `!recording`
- Lắng nghe `recording:start/stop` từ `recorder.js` relay qua `window.postMessage`

> MAIN world scripts không nhận được `chrome.tabs.sendMessage` trực tiếp (chỉ đến ISOLATED world). Relay path: SW → `recorder.js` (ISOLATED) → `window.postMessage` → capture scripts.

### `content/recorder.js` — relay recording state xuống MAIN world
- `startRecording()` broadcast `{ source: 'debug-helper-isolated', type: 'recording:start' }`
- `stopRecording()` broadcast `recording:stop`

### `background/service-worker.js` — clear setInterval khi stop
- Chuyển `setInterval` vào `startKeepalive()`, lưu ID
- `stopKeepalive()` gọi `clearInterval`
- Xóa standalone `setInterval` ở module level

## Test

- [ ] Start recording trên Vite dev server, trigger 10+ HMR reload
- [ ] Stop recording — CPU extension trong Chrome Task Manager (`Shift+Esc`) về 0% và giữ nguyên
- [ ] Bật recording mới — console log và network request vẫn capture bình thường
- [ ] Trigger HMR full reload trong khi đang recording — events vẫn xuất hiện sau reload (recorder.js relay `recording:start` khi restore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)